### PR TITLE
Create pinebookpro-overlay.conf

### DIFF
--- a/pinebookpro-overlay.conf
+++ b/pinebookpro-overlay.conf
@@ -1,0 +1,8 @@
+[pinebookpro-overlay]
+location = /var/db/repos/pinebookpro-overlay
+sync-type = git
+sync-uri = https://github.com/Jannik2099/pinebookpro-overlay.git
+ 
+location = /var/db/repos/pinebookpro-overlay
+priority = 100
+auto-sync = yes


### PR DESCRIPTION
wget   ..... githubraw /Jannik2099/pinebookpro-overlay  - O /etc/portage/repos.conf/pinebookpro-overlay.conf
also useful to add. as just git is needed. though the repo select is preferable. 
however build push to docker vm hopefully dump tarball to dir of host.. 
the conf file is simple to add to a docker rootfs. 

however playing the qemu game static  sucks..  but docker to meddle out.. a built system image in future might be a plus..  (hub.docker... has many a lunch break in cloud only build fails...) 

for packages, (need to likely block packages) .... from [sakaki](https://github.com/sakaki-/gentoo-on-rpi-64bit)- i'll abuse the bins to save compile times from their  rpi4  [binhost](https://isshoni.org/pi64pie/)...  ,   or force to add panfrost and bifrost/etc for rock64 etc.. on 
revdep-rebuild... 
however i still have rpi3 with image may add rpi4 etc to use as nodes and distcc etc.. 
with work and rented chroot , ie slcaleway i managed to port over even [pentoo](https://github.com/pentoo/pentoo-overlay)... packages. sadly bit stale by now... 


sync-uri = https://github.com/psychedup/gentoo-pine64.git , contrib'd  a ebuilds for aufuns kernel . 
rock64pro , atm .. few ebuilds swiped from Chromeos.  ie https://github.com/ayufan-rock64/chromiumos-build 
panfrost kernel , ebuild added.  and ayufan 5.x kernel ....


Grub2 can be built for zfs+ uboot + efi.... , etc.. etc. 
which could make dynamic swapping of kernels etc more easy.  for custom or rebuilt kernels or added patches , aufs, 
[parts + /boot/efi , /boot , /  would require some tweaks. etc.. } 
120 EFI , 550 boot... grub-uefi etc... , / 
sys-boot/refind can also be added to a few arm64 boxes.. 
https://github.com/andreiw/rk3399-edk2  hopefully the port to the laptop is added.. in future.. 

and uefi firmware package can be added. and hopefull a better buildroot also.. 

 for the moment i have the rock64pro with TS , case i wish had space for camera. etc.. 
just enough room for screen...



atm the laptop is on back order ... from the pine64 store.. but have chromeos on rock64pro.. 

hopefully i can build a rootfs  /pinebookpro/($CHROOT)  with these..  and push to newer emmc over usb.. 


https://gist.github.com/tstellanova/dea7593a7dfe4f48432a58cb007e7056 